### PR TITLE
Update CESKalman_Bootstrap.R

### DIFF
--- a/R/CESKalman_Bootstrap.R
+++ b/R/CESKalman_Bootstrap.R
@@ -18,12 +18,16 @@
 #' grid.param_init can be a vector of any length. Values to loop over for the variance of error term in observation equation, \eqn{\epsilon_t}, in the numerical optimization. When lambda is FALSE, differen values
 #' for the signal-to-noise ratio in the range from 10-1000 found to be optimal in Kronborg et al (2019) are tried. The one that maximizes the likelihood is chosen.
 #'
+#' Only draws with no autocorrelation in the estimated model and the NIS test within the limits specified in cVal_NIS is accepted.
+#'
 #' @param Estimation An object of class CESKalman
 #' @param grid.param_init A vector of initial Parameter values of the observation variance to loop over (see details)
 #' @param ndraw The number of draws in the bootstrapping procedure, 1000 is default.
 #' @param print_results Should results be printed while bootstrapping?
-#'
-#' @usage CESKalman_Bootstrap(Estimation,grid.param_init=c(-9,-1,3),ndraw=1000,print_results=TRUE)
+#' @param cVal_auto Critical value for the Breusch-Godfrey test for autocorrelation
+#' @param cVal_NIS Critical value for the NIS test 
+#' 
+#' @usage CESKalman_Bootstrap(Estimation,grid.param_init=c(-9,-1,3),ndraw=1000,print_results=TRUE,cVal_Auto=0.1,cVal_NIS=0.1)
 #
 #'
 #'
@@ -58,7 +62,7 @@
 # Starting function
 # ===================================================================
 
-CESKalman_Bootstrap <- function(Estimation,grid.param_init=c(-9,-1,5),ndraw=1000,print_results=TRUE){
+CESKalman_Bootstrap <- function(Estimation,grid.param_init=c(-9,-1,5),ndraw=1000,cVal_NIS=0.10,cVal_Auto=0.10,print_results=TRUE){
 
 
   ## Start bootstrapping
@@ -150,23 +154,23 @@ CESKalman_Bootstrap <- function(Estimation,grid.param_init=c(-9,-1,5),ndraw=1000
 
 
     tmp = CESKalman_Estimation(Y=Y_boot,X=X_boot,grid.param_init=grid.param_init,nlags=nlags,lambda=Estimation$est.lambda,Leontief=FALSE,alpha_init=Estimation$alpha,sigma_init=Estimation$sigma,
-                                cVal_NIS=0.10)
-
+                                cVal_NIS=cVal_NIS)
+if(tmp$BG_test>cVal_Auto&tmp$NIS_test[1]>tmp$NIS_test[2]&tmp$NIS_test[1]<tmp$NIS_test[3]){
       boot_alpha[k] = tmp$alpha
       boot_sigma[k]  = tmp$sigma
       boot_likelihood[k] = tmp$LV
       k <- k + 1
 
     nacc = nacc+1
-
+}
     nacc_ratio= k/nacc
-# if(print_results){
-#     if(k %% 10 == 0){
-#       cat("\014")
-#       cat(paste("This is draw number ",k,sep=""), "\n")
-#   #    cat(paste("Acceptance ratio ",round(nacc_ratio,digits=2)), "\n")
-#     }
-# }
+if(print_results){
+    if(k %% 10 == 0){
+      cat("\014")
+      cat(paste("This is draw number ",k,sep=""), "\n")
+  #    cat(paste("Acceptance ratio ",round(nacc_ratio,digits=2)), "\n")
+    }
+}
   }
 if(print_results){
   cat("\014")


### PR DESCRIPTION
An accept/reject criterion is introduced where only draws with no autocorrelation and a value of the NIS test within the confidence region are accepted.